### PR TITLE
Normalize eventTime format to iso8601

### DIFF
--- a/lib/predictionio/event_client.rb
+++ b/lib/predictionio/event_client.rb
@@ -112,7 +112,7 @@ module PredictionIO
     # See also #create_event.
     def acreate_event(event, entity_type, entity_id, optional = {})
       h = optional.with_indifferent_access
-      h.key?('eventTime') || h['eventTime'] = DateTime.now.to_s
+      h.key?('eventTime') || h['eventTime'] = DateTime.now.iso8601
       h['event'] = event
       h['entityType'] = entity_type
       h['entityId'] = entity_id


### PR DESCRIPTION
According to the [PredictionIO EventServer documentation](https://predictionio.incubator.apache.org/datacollection/eventapi/#event-creation-api). The time must be in ISO8601 format, otherwise the event will not be successfully created.

Before:

```ruby
[9] pry(main)> x = PIO::EventClient.set_user(111)
  HTTP POST (29.63ms)   http://192.168.20.4:7070/events.json?accessKey=<masked>
  Request body   {"eventTime":"2017-07-24 14:43:26","event":"$set","entityType":"user","entityId":111}
  Response status   Net::HTTPBadRequest (400)
  Response body   {"message":"org.json4s.package$MappingException: Fail to extract eventTime 2017-07-24 14:43:26"}
PredictionIO::EventClient::NotCreatedError: {"message":"org.json4s.package$MappingException: Fail to extract eventTime 2017-07-24 14:43:26"}
from /Users/shou/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/predictionio-0.9.6/lib/predictionio/event_client.rb:333:in `sync_events'
```

Where it should be:

```ruby
[10] pry(main)> x = PIO::EventClient.set_user(111, 'eventTime' => Time.now.iso8601)
  HTTP POST (90.27ms)   http://192.168.20.4:7070/events.json?accessKey=<masked>
  Request body   {"eventTime":"2017-07-24T14:43:48+08:00","event":"$set","entityType":"user","entityId":111}
  Response status   Net::HTTPCreated (201)
  Response body   {"eventId":"Kmgu6x9SvJQtjsepaRECjAAAAV1zVmSghsZcqOIsot8"}
=> #<Net::HTTPCreated 201 Created readbody=true>
```