### PR TITLE
Add support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1.5
   - 2.2.7
-  - 2.3.4
+  - 2.3.5
+  - 2.4.2
 script:
   - rake

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'coveralls', require: false
-  gem 'rspec', '~> 3.1.0'
-  gem 'webmock', '~> 1.20.4'
+  gem 'rspec', '~> 3.6.0'
+  gem 'webmock', '~> 2.3.2'
 end
 
 group :doc do

--- a/predictionio.gemspec
+++ b/predictionio.gemspec
@@ -18,5 +18,5 @@ EOF
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.0'
   s.files = Dir[File.join('lib', '**', '**')]
-  s.add_runtime_dependency 'json', '~> 1.8'
+  s.add_runtime_dependency 'json', '>= 1.8'
 end


### PR DESCRIPTION
This PR updates the versions of rspec and webmock to support Ruby 2.4, and relaxes the version constraint on the json gem to allow 2.x versions that are required for Ruby 2.4.

I tried checking [here](https://predictionio.atlassian.net/browse/SDKRUBY) for an open issue about this, but the Atlassian site repeatedly says the board isn't available.

If this PR is accepted then it would be great if someone could please cut a new release on rubygems. (although the version should go from 0.9.x to 0.10.x if you're dropping support for Ruby 1.9.3, which the current `develop` branch does)